### PR TITLE
Deal with invalid number that start with two 0s

### DIFF
--- a/bytes.go
+++ b/bytes.go
@@ -22,7 +22,7 @@ func parseInt(bytes []byte) (v int64, ok bool, overflow bool) {
 			return 0, false, false
 		}
 		// Deal with invalid data such as "00"
-		if c == '0' && n == 0 && idx != 0 {
+		if n == 0 && idx != 0 {
 			return 0, false, false
 		}
 		if n > maxUint64/10 {

--- a/bytes.go
+++ b/bytes.go
@@ -21,7 +21,7 @@ func parseInt(bytes []byte) (v int64, ok bool, overflow bool) {
 		if c < '0' || c > '9' {
 			return 0, false, false
 		}
-		// Deal with invalid JSON such as "00"
+		// Deal with invalid data such as "00"
 		if c == '0' && n == 0 && idx != 0 {
 			return 0, false, false
 		}

--- a/bytes.go
+++ b/bytes.go
@@ -17,8 +17,12 @@ func parseInt(bytes []byte) (v int64, ok bool, overflow bool) {
 	}
 
 	var n uint64 = 0
-	for _, c := range bytes {
+	for idx, c := range bytes {
 		if c < '0' || c > '9' {
+			return 0, false, false
+		}
+		// Deal with invalid JSON such as "00"
+		if c == '0' && n == 0 && idx != 0 {
 			return 0, false, false
 		}
 		if n > maxUint64/10 {

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -98,6 +98,10 @@ var parseIntTests = []ParseIntTest{
 		isErr:      true,
 		isOverflow: true,
 	},
+	{
+		in:    "00",
+		isErr: true,
+	},
 }
 
 func TestBytesParseInt(t *testing.T) {

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -102,6 +102,10 @@ var parseIntTests = []ParseIntTest{
 		in:    "00",
 		isErr: true,
 	},
+	{
+		in:    "010",
+		isErr: true,
+	},
 }
 
 func TestBytesParseInt(t *testing.T) {


### PR DESCRIPTION
Currently, `jsonparser.parseInt("00")` incorrectly parses to `0`. `00` is not a valid JSON and an error should be returned instead.