### PR TITLE
Detect invalid ending comma in object

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1110,8 +1110,9 @@ func ObjectEach(data []byte, callback func(key []byte, value []byte, dataType Va
 		case '"':
 			offset++ // accept as string and skip opening quote
 		case '}':
+			// Detect if the previous token was a comma. For rxample: { "": 12,}
 			if lastCommaIdx != -1 && lastCommaIdx+1 == offset {
-				// e.g. { "": 12,}
+
 				return MalformedObjectError
 			}
 			return nil // we found the end of the object; stop and return success

--- a/parser_test.go
+++ b/parser_test.go
@@ -1630,6 +1630,11 @@ var objectEachTests = []ObjectEachTest{
 		json:  `{"key": "value",, "key2": "value2"}`,
 		isErr: true,
 	},
+	{
+		desc:  "bad value (extra comma)",
+		json:  `{"":[],}`,
+		isErr: true,
+	},
 }
 
 func TestObjectEach(t *testing.T) {


### PR DESCRIPTION
Currently, the `ObjectEach` method is not able to detect objects with invalid ending comma, such as: `{"":[],}`. To fix this, we track the index of the lastCommaIdx (ignoring the skipped tokens) and return an error if it is followed by a `}`.