### PR TITLE
fix(parser): handle empty path elements in set operation

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -620,7 +620,10 @@ var (
 )
 
 func createInsertComponent(keys []string, setValue []byte, comma, object bool) []byte {
-	isIndex := string(keys[0][0]) == "["
+	isIndex := false
+	if len(keys) > 0 && len(keys[0]) > 0 {
+		isIndex = string(keys[0][0]) == "["
+	}
 	offset := 0
 	lk := calcAllocateSpace(keys, setValue, comma, object)
 	buffer := make([]byte, lk, lk)
@@ -667,7 +670,10 @@ func createInsertComponent(keys []string, setValue []byte, comma, object bool) [
 }
 
 func calcAllocateSpace(keys []string, setValue []byte, comma, object bool) int {
-	isIndex := string(keys[0][0]) == "["
+	isIndex := false
+	if len(keys) > 0 && len(keys[0]) > 0 {
+		isIndex = string(keys[0][0]) == "["
+	}
 	lk := 0
 	if comma {
 		// ,

--- a/parser_test.go
+++ b/parser_test.go
@@ -443,6 +443,14 @@ var setTests = []SetTest{
 		setData: `"new object"`,
 		data:    `{"test":{"key":[{"innerKey":"innerKeyValue", "innerKey2":"innerKeyValue2"},{"newInnerKey":"new object"}]}}`,
 	},
+	{
+		desc:    "set unknown key (simple object within nested array, with empty path)",
+		json:    `{"key":"val-obj1"}`,
+		isFound: true,
+		path:    []string{"key", ""},
+		setData: `"new object"`,
+		data:    `{"key":{"":"new object"}}`,
+	},
 }
 
 var getTests = []GetTest{


### PR DESCRIPTION
**Description**: What this PR does
- fix panic when setting empty("") key in a json
- Improve index detection in createInsertComponent and calcAllocateSpace functions
- Add test case for setting unknown key with empty path element in nested array

code panics when we try to set an empty key in json. In this PR I am trying to fix this. 

code to reproduce the issue
```go
 import (
	"fmt"

	"github.com/grafana/jsonparser"
)

func main() {
	bytes := []byte(`{"user": {"name": "John", "age": 30}}`)

	// this works
	new, err := jsonparser.Set(bytes, []byte(`"amy"`), "user", "name")
	if err != nil {
		fmt.Println(err)
	}
	fmt.Println(string(new)) // prints {"user": {"name": "amy", "age": 30}}

	// now we want to create a json like this
	// {
	//    "user": {
	//    "name": "amy",
	//    "age": 30,
	//    "": "amy"
	//   }
	// }
        // and this is a valid json
	// setting an empty key panics
	empty, err := jsonparser.Set(new, []byte(`"amy"`), "user", "") // this panics
	if err != nil {
		fmt.Println(err)
	}
	fmt.Println(string(empty))
}

```

**Benchmark before change**:

**Benchmark after change**:


For running benchmarks use:
```
go test -test.benchmem -bench JsonParser ./benchmark/ -benchtime 5s -v
# OR
make bench (runs inside docker)
```